### PR TITLE
feat: make system cards customizable

### DIFF
--- a/src/components/SystemCard.vue
+++ b/src/components/SystemCard.vue
@@ -1,35 +1,16 @@
 <template>
-  <v-card
-    class="mx-auto"
-    max-width="344"
-  >
+  <v-card class="mx-auto" max-width="344">
     <v-card-text>
-      <div>Word of the Day</div>
-
-      <p class="text-h4 font-weight-black">be•nev•o•lent</p>
-
-      <p>adjective</p>
-
-      <div class="text-medium-emphasis">
-        well meaning and kindly.<br>
-        "a benevolent smile"
-      </div>
+      <slot />
     </v-card-text>
-
     <v-card-actions>
-      <v-btn
-        color="deep-purple-accent-4"
-        text="Learn More"
-        variant="text"
-      />
+      <slot name="actions" />
     </v-card-actions>
   </v-card>
 </template>
 
 <script setup>
-
 </script>
 
 <style scoped lang="sass">
-
 </style>

--- a/src/pages/SystemMonitoring.vue
+++ b/src/pages/SystemMonitoring.vue
@@ -1,8 +1,35 @@
 <template>
   <p>系統監控</p>
-  <SystemCard />
+  <div class="d-flex flex-wrap gap-4">
+    <SystemCard v-for="(item, index) in systems" :key="index">
+      <template #default>
+        <div>容器 IP：{{ item.ip }}</div>
+        <p class="text-h4 font-weight-black">網路使用量：{{ item.networkUsage }}</p>
+        <p>啟用狀態：{{ item.isActive ? '啟用' : '停用' }}</p>
+      </template>
+      <template #actions>
+        <v-btn color="deep-purple-accent-4" variant="text">查看更多</v-btn>
+      </template>
+    </SystemCard>
+  </div>
 </template>
 
 <script setup>
-  //
+  const systems = [
+    {
+      ip: '192.168.0.10',
+      networkUsage: '120MB/s',
+      isActive: true,
+    },
+    {
+      ip: '192.168.0.11',
+      networkUsage: '80MB/s',
+      isActive: false,
+    },
+    {
+      ip: '192.168.0.12',
+      networkUsage: '200MB/s',
+      isActive: true,
+    },
+  ]
 </script>


### PR DESCRIPTION
## Summary
- allow SystemCard to accept slotted content and actions
- render mock container data with IP, network usage, and active status in SystemMonitoring

## Testing
- `npm run lint` *(fails: '/workspace/iot_rkpweb/node_modules/vue-router/dist/vue-router.mjs' imported multiple times)*

------
https://chatgpt.com/codex/tasks/task_e_68972d7b48f88324b8a062565df0493d