### PR TITLE
feat: add floating navigation menu button

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -19,10 +19,16 @@
       </div>
     </v-list-item>
   </v-navigation-drawer>
+  <v-main />
 
-  <v-main class="d-flex align-center justify-center">
-    <v-switch v-model="open" color="success" />
-  </v-main>
+  <v-btn
+    class="drawer-toggle"
+    color="primary"
+    icon
+    @click="open = !open"
+  >
+    <v-icon icon="mdi-menu" />
+  </v-btn>
 </template>
 
 <script setup>
@@ -53,5 +59,9 @@
 </script>
 
 <style scoped lang="scss">
-
+  .drawer-toggle {
+    position: fixed;
+    bottom: 16px;
+    left: 16px;
+  }
 </style>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -61,7 +61,7 @@
 <style scoped lang="scss">
   .drawer-toggle {
     position: fixed;
-    bottom: 16px;
+    bottom: 72px;
     left: 16px;
   }
 </style>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -19,7 +19,6 @@
       </div>
     </v-list-item>
   </v-navigation-drawer>
-  <v-main />
 
   <v-btn
     class="drawer-toggle"


### PR DESCRIPTION
## Summary
- replace switch with floating menu icon to toggle navigation drawer
- add fixed bottom-left styling for toggle button

## Testing
- `npm run lint` *(fails: '/workspace/iot_rkpweb/node_modules/vue-router/dist/vue-router.mjs' imported multiple times)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897fa96232083249b6ca2696336c9e6