### PR TITLE
Adjust SystemCard width and switch component styles to SCSS

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -71,12 +71,14 @@
   ]
 </script>
 
-<style scoped lang="sass">
-  .social-link :deep(.v-icon)
-    color: rgba(var(--v-theme-on-background), var(--v-disabled-opacity))
-    text-decoration: none
-    transition: .2s ease-in-out
+<style scoped lang="scss">
+  .social-link :deep(.v-icon) {
+    color: rgba(var(--v-theme-on-background), var(--v-disabled-opacity));
+    text-decoration: none;
+    transition: .2s ease-in-out;
 
-    &:hover
-      color: rgba(25, 118, 210, 1)
+    &:hover {
+      color: rgba(25, 118, 210, 1);
+    }
+  }
 </style>

--- a/src/components/SystemCard.vue
+++ b/src/components/SystemCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="mx-auto" max-width="344">
+  <v-card class="system-card">
     <v-card-text>
       <slot />
     </v-card-text>
@@ -12,5 +12,9 @@
 <script setup>
 </script>
 
-<style scoped lang="sass">
+<style scoped lang="scss">
+.system-card {
+  width: 192px;
+  margin: 4px;
+}
 </style>


### PR DESCRIPTION
## Summary
- size SystemCard to 192px wide with 4px margins to allow four cards per row with 8px spacing in 800x480 layout
- replace SASS style tags with SCSS syntax in AppFooter and SystemCard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689805db57a483249258e9d566accbb2