### PR TITLE
Add titles to monitoring pages

### DIFF
--- a/src/pages/ContainerManagement.vue
+++ b/src/pages/ContainerManagement.vue
@@ -1,5 +1,6 @@
 <template>
-  <v-container>
+  <v-container class="pa-4">
+    <v-card-title>容器管理</v-card-title>
     <v-table>
       <thead>
         <tr>
@@ -31,21 +32,22 @@
         </tr>
       </tbody>
     </v-table>
-    <v-dialog v-model="settingsDialog" max-width="400">
-      <v-card>
-        <v-card-title>設定</v-card-title>
-        <v-card-text>
-          <v-text-field v-model="settings.field1" label="設定 1" />
-          <v-text-field v-model="settings.field2" label="設定 2" />
-          <v-select v-model="settings.option" :items="options" label="選項" />
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn color="primary" @click="saveSettings">送出</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
   </v-container>
+
+  <v-dialog v-model="settingsDialog" max-width="400">
+    <v-card>
+      <v-card-title>設定</v-card-title>
+      <v-card-text>
+        <v-text-field v-model="settings.field1" label="設定 1" />
+        <v-text-field v-model="settings.field2" label="設定 2" />
+        <v-select v-model="settings.option" :items="options" label="選項" />
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="primary" @click="saveSettings">送出</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script setup>

--- a/src/pages/SystemMonitoring.vue
+++ b/src/pages/SystemMonitoring.vue
@@ -1,20 +1,22 @@
 <template>
-  <p>系統監控</p>
-  <div class="d-flex flex-wrap gap-4">
-    <SystemCard v-for="(item, index) in systems" :key="index">
-      <template #default>
-        <div>容器 IP：{{ item.ip }}</div>
-        <p class="text-h4 font-weight-black">網路使用量：{{ item.networkUsage }}</p>
-        <p>啟用狀態：{{ item.isActive ? '啟用' : '停用' }}</p>
-      </template>
-      <template #actions>
-        <v-btn icon variant="text" @click="openLogs(item)">
-          <v-icon>mdi-file-document-outline</v-icon>
-        </v-btn>
-        <v-btn color="deep-purple-accent-4" variant="text">查看更多</v-btn>
-      </template>
-    </SystemCard>
-  </div>
+  <v-container class="pa-4">
+    <v-card-title>系統監控</v-card-title>
+    <div class="d-flex flex-wrap gap-4">
+      <SystemCard v-for="(item, index) in systems" :key="index">
+        <template #default>
+          <div>容器 IP：{{ item.ip }}</div>
+          <p class="text-h4 font-weight-black">網路使用量：{{ item.networkUsage }}</p>
+          <p>啟用狀態：{{ item.isActive ? '啟用' : '停用' }}</p>
+        </template>
+        <template #actions>
+          <v-btn icon variant="text" @click="openLogs(item)">
+            <v-icon>mdi-file-document-outline</v-icon>
+          </v-btn>
+          <v-btn color="deep-purple-accent-4" variant="text">查看更多</v-btn>
+        </template>
+      </SystemCard>
+    </div>
+  </v-container>
 
   <v-dialog v-model="logsDialog" max-width="600">
     <v-card>


### PR DESCRIPTION
## Summary
- show title for SystemMonitoring page
- show title for ContainerManagement page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68988ac33d9c8324bfaac6473441fec2