### PR TITLE
feat: Wrap container table in card

### DIFF
--- a/src/components/SystemCard.vue
+++ b/src/components/SystemCard.vue
@@ -14,7 +14,6 @@
 
 <style scoped lang="scss">
 .system-card {
-  width: 192px;
-  margin: 4px;
+  width: 100%;
 }
 </style>

--- a/src/pages/ContainerManagement.vue
+++ b/src/pages/ContainerManagement.vue
@@ -1,36 +1,41 @@
 <template>
-  <v-container>
-    <v-table>
-      <thead>
-        <tr>
-          <th class="text-left">容器名稱</th>
-          <th class="text-left">容器IP</th>
-          <th class="text-left">網卡名稱</th>
-          <th class="text-left">功能</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="(container, index) in containers" :key="index">
-          <td>{{ container.name }}</td>
-          <td>{{ container.ip }}</td>
-          <td>{{ container.nic }}</td>
-          <td>
-            <v-btn icon size="x-large" variant="text" @click="toggle(container)">
-              <v-icon size="x-large">{{ container.enabled ? 'mdi-pause-circle' : 'mdi-play-circle' }}</v-icon>
-            </v-btn>
-            <v-btn icon size="x-large" variant="text" @click="duplicate(container)">
-              <v-icon size="x-large">mdi-content-copy</v-icon>
-            </v-btn>
-            <v-btn icon size="x-large" variant="text" @click="openSettings(container)">
-              <v-icon size="x-large">mdi-cog</v-icon>
-            </v-btn>
-            <v-btn icon size="x-large" variant="text" @click="remove(container)">
-              <v-icon size="x-large">mdi-delete</v-icon>
-            </v-btn>
-          </td>
-        </tr>
-      </tbody>
-    </v-table>
+  <v-container class="pa-4">
+    <v-card>
+      <v-card-title>容器管理</v-card-title>
+      <v-card-text>
+        <v-table>
+          <thead>
+            <tr>
+              <th class="text-left">容器名稱</th>
+              <th class="text-left">容器IP</th>
+              <th class="text-left">網卡名稱</th>
+              <th class="text-left">功能</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(container, index) in containers" :key="index">
+              <td>{{ container.name }}</td>
+              <td>{{ container.ip }}</td>
+              <td>{{ container.nic }}</td>
+              <td>
+                <v-btn icon size="x-large" variant="text" @click="toggle(container)">
+                  <v-icon size="x-large">{{ container.enabled ? 'mdi-pause-circle' : 'mdi-play-circle' }}</v-icon>
+                </v-btn>
+                <v-btn icon size="x-large" variant="text" @click="duplicate(container)">
+                  <v-icon size="x-large">mdi-content-copy</v-icon>
+                </v-btn>
+                <v-btn icon size="x-large" variant="text" @click="openSettings(container)">
+                  <v-icon size="x-large">mdi-cog</v-icon>
+                </v-btn>
+                <v-btn icon size="x-large" variant="text" @click="remove(container)">
+                  <v-icon size="x-large">mdi-delete</v-icon>
+                </v-btn>
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-card-text>
+    </v-card>
     <v-dialog v-model="settingsDialog" max-width="400">
       <v-card>
         <v-card-title>設定</v-card-title>

--- a/src/pages/ContainerManagement.vue
+++ b/src/pages/ContainerManagement.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="pa-4">
+  <v-container class="pa-4" fluid>
     <v-card>
       <v-card-title>容器管理</v-card-title>
       <v-card-text>

--- a/src/pages/SystemMonitoring.vue
+++ b/src/pages/SystemMonitoring.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="pa-4">
+  <v-container class="pa-4" fluid>
     <v-card>
       <v-card-title>系統監控</v-card-title>
       <v-card-text>

--- a/src/pages/SystemMonitoring.vue
+++ b/src/pages/SystemMonitoring.vue
@@ -1,47 +1,52 @@
 <template>
-  <p>系統監控</p>
-  <div class="d-flex flex-wrap gap-4">
-    <SystemCard v-for="(item, index) in systems" :key="index">
-      <template #default>
-        <div>容器 IP：{{ item.ip }}</div>
-        <p class="text-h4 font-weight-black">網路使用量：{{ item.networkUsage }}</p>
-        <p>啟用狀態：{{ item.isActive ? '啟用' : '停用' }}</p>
-      </template>
-      <template #actions>
-        <v-btn icon variant="text" @click="openLogs(item)">
-          <v-icon>mdi-file-document-outline</v-icon>
-        </v-btn>
-        <v-btn color="deep-purple-accent-4" variant="text">查看更多</v-btn>
-      </template>
-    </SystemCard>
-  </div>
-
-  <v-dialog v-model="logsDialog" max-width="600">
+  <v-container class="pa-4">
     <v-card>
-      <v-card-title>容器日誌</v-card-title>
+      <v-card-title>系統監控</v-card-title>
       <v-card-text>
-        <v-progress-circular v-if="logsLoading" color="primary" indeterminate />
-        <v-list v-else>
-          <v-list-item
-            v-for="log in logs"
-            :key="log.name"
-            :title="log.name"
-          >
-            <template #append>
-              <v-btn download :href="log.url" icon variant="text">
-                <v-icon>mdi-download</v-icon>
-              </v-btn>
+        <div class="d-flex flex-wrap gap-4">
+          <SystemCard v-for="(item, index) in systems" :key="index">
+            <template #default>
+              <div>容器 IP：{{ item.ip }}</div>
+              <p class="text-h4 font-weight-black">網路使用量：{{ item.networkUsage }}</p>
+              <p>啟用狀態：{{ item.isActive ? '啟用' : '停用' }}</p>
             </template>
-          </v-list-item>
-          <v-list-item v-if="logs.length === 0" title="沒有日誌" />
-        </v-list>
+            <template #actions>
+              <v-btn icon variant="text" @click="openLogs(item)">
+                <v-icon>mdi-file-document-outline</v-icon>
+              </v-btn>
+              <v-btn color="deep-purple-accent-4" variant="text">查看更多</v-btn>
+            </template>
+          </SystemCard>
+        </div>
       </v-card-text>
-      <v-card-actions>
-        <v-spacer />
-        <v-btn text @click="logsDialog = false">關閉</v-btn>
-      </v-card-actions>
     </v-card>
-  </v-dialog>
+    <v-dialog v-model="logsDialog" max-width="600">
+      <v-card>
+        <v-card-title>容器日誌</v-card-title>
+        <v-card-text>
+          <v-progress-circular v-if="logsLoading" color="primary" indeterminate />
+          <v-list v-else>
+            <v-list-item
+              v-for="log in logs"
+              :key="log.name"
+              :title="log.name"
+            >
+              <template #append>
+                <v-btn download :href="log.url" icon variant="text">
+                  <v-icon>mdi-download</v-icon>
+                </v-btn>
+              </template>
+            </v-list-item>
+            <v-list-item v-if="logs.length === 0" title="沒有日誌" />
+          </v-list>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn text @click="logsDialog = false">關閉</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
 </template>
 
 <script setup>

--- a/src/pages/SystemMonitoring.vue
+++ b/src/pages/SystemMonitoring.vue
@@ -3,28 +3,24 @@
     <v-card>
       <v-card-title>系統監控</v-card-title>
       <v-card-text>
-        <v-row>
-          <v-col
+        <div class="system-grid">
+          <SystemCard
             v-for="(item, index) in systems"
             :key="index"
-            cols="12"
-            md="4"
           >
-            <SystemCard>
-              <template #default>
-                <div>容器 IP：{{ item.ip }}</div>
-                <p class="text-h4 font-weight-black">網路使用量：{{ item.networkUsage }}</p>
-                <p>啟用狀態：{{ item.isActive ? '啟用' : '停用' }}</p>
-              </template>
-              <template #actions>
-                <v-btn icon variant="text" @click="openLogs(item)">
-                  <v-icon>mdi-file-document-outline</v-icon>
-                </v-btn>
-                <v-btn color="deep-purple-accent-4" variant="text">查看更多</v-btn>
-              </template>
-            </SystemCard>
-          </v-col>
-        </v-row>
+            <template #default>
+              <div>容器 IP：{{ item.ip }}</div>
+              <p class="text-h4 font-weight-black">網路使用量：{{ item.networkUsage }}</p>
+              <p>啟用狀態：{{ item.isActive ? '啟用' : '停用' }}</p>
+            </template>
+            <template #actions>
+              <v-btn icon variant="text" @click="openLogs(item)">
+                <v-icon>mdi-file-document-outline</v-icon>
+              </v-btn>
+              <v-btn color="deep-purple-accent-4" variant="text">查看更多</v-btn>
+            </template>
+          </SystemCard>
+        </div>
       </v-card-text>
     </v-card>
     <v-dialog v-model="logsDialog" max-width="600">
@@ -119,3 +115,29 @@
     }
   }
 </script>
+
+<style scoped>
+.system-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(1, 1fr);
+}
+
+@media (min-width: 800px) {
+  .system-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (min-width: 1200px) {
+  .system-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (min-width: 1800px) {
+  .system-grid {
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+</style>

--- a/src/pages/SystemMonitoring.vue
+++ b/src/pages/SystemMonitoring.vue
@@ -3,21 +3,28 @@
     <v-card>
       <v-card-title>系統監控</v-card-title>
       <v-card-text>
-        <div class="d-flex flex-wrap gap-4">
-          <SystemCard v-for="(item, index) in systems" :key="index">
-            <template #default>
-              <div>容器 IP：{{ item.ip }}</div>
-              <p class="text-h4 font-weight-black">網路使用量：{{ item.networkUsage }}</p>
-              <p>啟用狀態：{{ item.isActive ? '啟用' : '停用' }}</p>
-            </template>
-            <template #actions>
-              <v-btn icon variant="text" @click="openLogs(item)">
-                <v-icon>mdi-file-document-outline</v-icon>
-              </v-btn>
-              <v-btn color="deep-purple-accent-4" variant="text">查看更多</v-btn>
-            </template>
-          </SystemCard>
-        </div>
+        <v-row>
+          <v-col
+            v-for="(item, index) in systems"
+            :key="index"
+            cols="12"
+            md="4"
+          >
+            <SystemCard>
+              <template #default>
+                <div>容器 IP：{{ item.ip }}</div>
+                <p class="text-h4 font-weight-black">網路使用量：{{ item.networkUsage }}</p>
+                <p>啟用狀態：{{ item.isActive ? '啟用' : '停用' }}</p>
+              </template>
+              <template #actions>
+                <v-btn icon variant="text" @click="openLogs(item)">
+                  <v-icon>mdi-file-document-outline</v-icon>
+                </v-btn>
+                <v-btn color="deep-purple-accent-4" variant="text">查看更多</v-btn>
+              </template>
+            </SystemCard>
+          </v-col>
+        </v-row>
       </v-card-text>
     </v-card>
     <v-dialog v-model="logsDialog" max-width="600">
@@ -66,6 +73,31 @@
     {
       ip: '192.168.0.12',
       networkUsage: '200MB/s',
+      isActive: true,
+    },
+    {
+      ip: '192.168.0.13',
+      networkUsage: '150MB/s',
+      isActive: true,
+    },
+    {
+      ip: '192.168.0.14',
+      networkUsage: '60MB/s',
+      isActive: false,
+    },
+    {
+      ip: '192.168.0.15',
+      networkUsage: '90MB/s',
+      isActive: true,
+    },
+    {
+      ip: '192.168.0.16',
+      networkUsage: '110MB/s',
+      isActive: false,
+    },
+    {
+      ip: '192.168.0.17',
+      networkUsage: '70MB/s',
       isActive: true,
     },
   ]

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,16 +1,16 @@
+import { fileURLToPath, URL } from 'node:url'
+import Vue from '@vitejs/plugin-vue'
 // Plugins
 import AutoImport from 'unplugin-auto-import/vite'
-import Components from 'unplugin-vue-components/vite'
 import Fonts from 'unplugin-fonts/vite'
-import Layouts from 'vite-plugin-vue-layouts-next'
-import Vue from '@vitejs/plugin-vue'
-import VueRouter from 'unplugin-vue-router/vite'
+import Components from 'unplugin-vue-components/vite'
 import { VueRouterAutoImports } from 'unplugin-vue-router'
-import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
-
+import VueRouter from 'unplugin-vue-router/vite'
 // Utilities
 import { defineConfig } from 'vite'
-import { fileURLToPath, URL } from 'node:url'
+
+import Layouts from 'vite-plugin-vue-layouts-next'
+import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Wrap container management table and title within a Vuetify card for consistent layout and padding

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68988cb18b048324a891f13069815b3b