### PR TITLE
feat: add reverse proxy configuration page

### DIFF
--- a/src/pages/ReverseProxyConfiguration.vue
+++ b/src/pages/ReverseProxyConfiguration.vue
@@ -16,7 +16,9 @@
               <th class="text-left col-protocol">協定</th>
               <th class="text-left col-container-ip">容器IP</th>
               <th class="text-left col-container-port">容器Port</th>
-              <th class="text-left col-actions">刪除</th>
+              <th class="text-center col-actions">
+                <v-icon icon="mdi-delete" />
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -296,6 +298,8 @@
     width: 120px;
   }
   .col-actions {
-    width: 80px;
+    width: 40px;
+    max-width: 40px;
+    padding: 0;
   }
 </style>

--- a/src/pages/ReverseProxyConfiguration.vue
+++ b/src/pages/ReverseProxyConfiguration.vue
@@ -1,7 +1,185 @@
 <template>
-  <p>反向代理</p>
+  <v-container class="pa-4" fluid>
+    <v-card>
+      <v-card-title>
+        反向代理設定
+        <v-spacer />
+        <v-btn color="primary" @click="save">儲存</v-btn>
+      </v-card-title>
+      <v-card-text>
+        <v-table>
+          <thead>
+            <tr>
+              <th class="text-left">網路介面</th>
+              <th class="text-left">上位IP</th>
+              <th class="text-left">上位Port</th>
+              <th class="text-left">協定</th>
+              <th class="text-left">容器IP</th>
+              <th class="text-left">容器Port</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(row, index) in rows" :key="index">
+              <td>
+                <v-select
+                  v-model="row.nic"
+                  density="compact"
+                  hide-details
+                  item-title="name"
+                  item-value="id"
+                  :items="networkInterfaces"
+                  return-object
+                />
+              </td>
+              <td>
+                <v-text-field
+                  v-model="row.upstreamIp"
+                  density="compact"
+                  hide-details
+                  :rules="[ipRule]"
+                  @input="row.upstreamIp = sanitizeIp(row.upstreamIp)"
+                />
+              </td>
+              <td>
+                <v-text-field
+                  v-model="row.upstreamPort"
+                  density="compact"
+                  hide-details
+                  :rules="[portRule]"
+                  @input="row.upstreamPort = sanitizePort(row.upstreamPort)"
+                />
+              </td>
+              <td>
+                <v-select
+                  v-model="row.protocol"
+                  density="compact"
+                  hide-details
+                  :items="protocols"
+                />
+              </td>
+              <td>
+                <v-text-field
+                  v-model="row.containerIp"
+                  density="compact"
+                  hide-details
+                  :rules="[ipRule]"
+                  @input="row.containerIp = sanitizeIp(row.containerIp)"
+                />
+              </td>
+              <td>
+                <v-text-field
+                  v-model="row.containerPort"
+                  density="compact"
+                  hide-details
+                  :rules="[portRule]"
+                  @input="row.containerPort = sanitizePort(row.containerPort)"
+                />
+              </td>
+            </tr>
+            <tr>
+              <td class="text-center" colspan="6">
+                <v-btn icon="mdi-plus" variant="text" @click="addRow" />
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-card-text>
+    </v-card>
+  </v-container>
 </template>
 
 <script setup>
-  //
+  import { onMounted, ref } from 'vue'
+
+  const networkInterfaces = ref([])
+  const protocols = ['HTTP', 'HTTPS']
+
+  const rows = ref([
+    {
+      nic: null,
+      upstreamIp: '',
+      upstreamPort: '',
+      protocol: '',
+      containerIp: '',
+      containerPort: '',
+    },
+  ])
+
+  const ipv4Regex = /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/
+
+  const ipRule = v => !v || ipv4Regex.test(v) || '請輸入正確的IP格式'
+  const portRule = v => {
+    const n = Number(v)
+    return !v || (n >= 0 && n <= 65_535) || '請輸入正確的Port號'
+  }
+
+  function sanitizeIp (val) {
+    return val.replace(/[^\d.]/g, '')
+  }
+  function sanitizePort (val) {
+    return val.replace(/[^\d]/g, '')
+  }
+
+  function addRow () {
+    rows.value.push({
+      nic: null,
+      upstreamIp: '',
+      upstreamPort: '',
+      protocol: '',
+      containerIp: '',
+      containerPort: '',
+    })
+  }
+
+  async function save () {
+    for (const row of rows.value) {
+      if (
+        !ipv4Regex.test(row.upstreamIp)
+        || !ipv4Regex.test(row.containerIp)
+      ) {
+        alert('請輸入正確的IP格式')
+        return
+      }
+      const upPort = Number(row.upstreamPort)
+      const containerPort = Number(row.containerPort)
+      if (
+        Number.isNaN(upPort)
+        || Number.isNaN(containerPort)
+        || upPort < 0
+        || upPort > 65_535
+        || containerPort < 0
+        || containerPort > 65_535
+      ) {
+        alert('請輸入正確的Port號')
+        return
+      }
+    }
+    try {
+      await fetch('/api/reverse-proxy', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(rows.value),
+      })
+      alert('已儲存')
+    } catch {
+      alert('儲存失敗')
+    }
+  }
+
+  onMounted(async () => {
+    try {
+      const nicRes = await fetch('/api/network-interfaces')
+      networkInterfaces.value = nicRes.ok ? await nicRes.json() : []
+    } catch {
+      networkInterfaces.value = []
+    }
+
+    try {
+      const res = await fetch('/api/reverse-proxy')
+      const data = res.ok ? await res.json() : []
+      if (Array.isArray(data) && data.length > 0) rows.value = data
+    } catch {
+    /* ignore */
+    }
+  })
 </script>

--- a/src/pages/ReverseProxyConfiguration.vue
+++ b/src/pages/ReverseProxyConfiguration.vue
@@ -16,7 +16,7 @@
               <th class="text-left col-protocol">協定</th>
               <th class="text-left col-container-ip">容器IP</th>
               <th class="text-left col-container-port">容器Port</th>
-              <th class="text-center col-actions">
+              <th class="text-center col-delete">
                 <v-icon icon="mdi-delete" />
               </th>
             </tr>
@@ -79,7 +79,7 @@
                   @input="row.containerPort = sanitizePort(row.containerPort)"
                 />
               </td>
-              <td class="text-center col-actions">
+              <td class="text-center col-delete">
                 <v-btn
                   icon="mdi-delete"
                   variant="text"
@@ -273,31 +273,31 @@
 </script>
 
 <style scoped>
-  .proxy-table th,
-  .proxy-table td {
-    width: 150px;
-    max-width: 150px;
-  }
-
   .col-nic {
     width: 120px;
+    max-width: 120px;
   }
   .col-upstream-ip {
     width: 160px;
+    max-width: 160px;
   }
   .col-upstream-port {
     width: 120px;
+    max-width: 120px;
   }
   .col-protocol {
     width: 100px;
+    max-width: 100px;
   }
   .col-container-ip {
     width: 160px;
+    max-width: 160px;
   }
   .col-container-port {
     width: 120px;
+    max-width: 120px;
   }
-  .col-actions {
+  .col-delete {
     width: 40px;
     max-width: 40px;
     padding: 0;

--- a/src/pages/ReverseProxyConfiguration.vue
+++ b/src/pages/ReverseProxyConfiguration.vue
@@ -16,6 +16,7 @@
               <th class="text-left col-protocol">協定</th>
               <th class="text-left col-container-ip">容器IP</th>
               <th class="text-left col-container-port">容器Port</th>
+              <th class="text-left col-actions">刪除</th>
             </tr>
           </thead>
           <tbody>
@@ -76,14 +77,31 @@
                   @input="row.containerPort = sanitizePort(row.containerPort)"
                 />
               </td>
+              <td class="text-center col-actions">
+                <v-btn
+                  icon="mdi-delete"
+                  variant="text"
+                  @click="openDelete(index)"
+                />
+              </td>
             </tr>
             <tr>
-              <td class="text-center" colspan="6">
+              <td class="text-center" colspan="7">
                 <v-btn icon="mdi-plus" variant="text" @click="addRow" />
               </td>
             </tr>
           </tbody>
         </v-table>
+        <v-dialog v-model="deleteDialog" max-width="320">
+          <v-card>
+            <v-card-title class="text-h6">確認刪除該列？</v-card-title>
+            <v-card-actions>
+              <v-spacer />
+              <v-btn variant="text" @click="deleteDialog = false">否</v-btn>
+              <v-btn variant="text" @click="deleteRow">是</v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-dialog>
       </v-card-text>
     </v-card>
   </v-container>
@@ -175,6 +193,19 @@
     }
   }
 
+  const deleteDialog = ref(false)
+  const deleteIndex = ref(null)
+
+  function openDelete (index) {
+    deleteIndex.value = index
+    deleteDialog.value = true
+  }
+  function deleteRow () {
+    if (deleteIndex.value !== null) rows.value.splice(deleteIndex.value, 1)
+    deleteDialog.value = false
+    deleteIndex.value = null
+  }
+
   function addRow () {
     rows.value.push({
       nic: null,
@@ -263,5 +294,8 @@
   }
   .col-container-port {
     width: 120px;
+  }
+  .col-actions {
+    width: 80px;
   }
 </style>

--- a/src/pages/ReverseProxyConfiguration.vue
+++ b/src/pages/ReverseProxyConfiguration.vue
@@ -7,20 +7,20 @@
         <v-btn color="primary" @click="save">儲存</v-btn>
       </v-card-title>
       <v-card-text>
-        <v-table>
+        <v-table class="proxy-table">
           <thead>
             <tr>
-              <th class="text-left">網路介面</th>
-              <th class="text-left">上位IP</th>
-              <th class="text-left">上位Port</th>
-              <th class="text-left">協定</th>
-              <th class="text-left">容器IP</th>
-              <th class="text-left">容器Port</th>
+              <th class="text-left col-nic">網路介面</th>
+              <th class="text-left col-upstream-ip">上位IP</th>
+              <th class="text-left col-upstream-port">上位Port</th>
+              <th class="text-left col-protocol">協定</th>
+              <th class="text-left col-container-ip">容器IP</th>
+              <th class="text-left col-container-port">容器Port</th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="(row, index) in rows" :key="index">
-              <td>
+              <td class="col-nic">
                 <v-select
                   v-model="row.nic"
                   density="compact"
@@ -31,7 +31,7 @@
                   return-object
                 />
               </td>
-              <td>
+              <td class="col-upstream-ip">
                 <v-text-field
                   v-model="row.upstreamIp"
                   density="compact"
@@ -40,7 +40,7 @@
                   @input="row.upstreamIp = sanitizeIp(row.upstreamIp)"
                 />
               </td>
-              <td>
+              <td class="col-upstream-port">
                 <v-text-field
                   v-model="row.upstreamPort"
                   density="compact"
@@ -49,7 +49,7 @@
                   @input="row.upstreamPort = sanitizePort(row.upstreamPort)"
                 />
               </td>
-              <td>
+              <td class="col-protocol">
                 <v-select
                   v-model="row.protocol"
                   density="compact"
@@ -57,7 +57,7 @@
                   :items="protocols"
                 />
               </td>
-              <td>
+              <td class="col-container-ip">
                 <v-combobox
                   v-model="row.containerIp"
                   density="compact"
@@ -67,7 +67,7 @@
                   @change="val => handleContainerIp(index, val)"
                 />
               </td>
-              <td>
+              <td class="col-container-port">
                 <v-text-field
                   v-model="row.containerPort"
                   density="compact"
@@ -115,18 +115,32 @@
       containerIp: '172.17.0.3',
       containerPort: '8443',
     },
+    {
+      nicId: 1,
+      upstreamIp: '192.168.1.12',
+      upstreamPort: '8080',
+      protocol: 'HTTP',
+      containerIp: '172.17.0.4',
+      containerPort: '8081',
+    },
+    {
+      nicId: 2,
+      upstreamIp: '192.168.1.13',
+      upstreamPort: '8443',
+      protocol: 'HTTPS',
+      containerIp: '172.17.0.5',
+      containerPort: '8444',
+    },
   ]
 
-  const rows = ref([
-    {
-      nic: null,
-      upstreamIp: '',
-      upstreamPort: '',
-      protocol: '',
-      containerIp: '',
-      containerPort: '',
-    },
-  ])
+  const rows = ref(savedConfigs.map(c => ({
+    nic: networkInterfaces.value.find(n => n.id === c.nicId) || null,
+    upstreamIp: c.upstreamIp,
+    upstreamPort: c.upstreamPort,
+    protocol: c.protocol,
+    containerIp: c.containerIp,
+    containerPort: c.containerPort,
+  })))
 
   const ipv4Regex = /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/
 
@@ -224,3 +238,30 @@
     }
   })
 </script>
+
+<style scoped>
+  .proxy-table th,
+  .proxy-table td {
+    width: 150px;
+    max-width: 150px;
+  }
+
+  .col-nic {
+    width: 120px;
+  }
+  .col-upstream-ip {
+    width: 160px;
+  }
+  .col-upstream-port {
+    width: 120px;
+  }
+  .col-protocol {
+    width: 100px;
+  }
+  .col-container-ip {
+    width: 160px;
+  }
+  .col-container-port {
+    width: 120px;
+  }
+</style>


### PR DESCRIPTION
## Summary
- add reverse proxy configuration page with editable table and save support

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68995905dd1483249d1ff652409ddb9b