### PR TITLE
feat: add theme toggle switch

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -18,6 +18,15 @@
         <p> {{ link.title }}</p>
       </div>
     </v-list-item>
+    <v-divider />
+    <v-list-item>
+      <v-switch
+        v-model="isDark"
+        color="primary"
+        inset
+        label="深色模式"
+      />
+    </v-list-item>
   </v-navigation-drawer>
 
   <v-btn
@@ -31,8 +40,25 @@
 </template>
 
 <script setup>
-  import { ref, shallowRef } from 'vue'
+  import { computed, onMounted, ref, shallowRef } from 'vue'
+  import { useTheme } from 'vuetify'
+
   const open = shallowRef(true)
+  const theme = useTheme()
+
+  const isDark = computed({
+    get: () => theme.global.current.value.dark,
+    set: val => {
+      const newTheme = val ? 'dark' : 'light'
+      theme.global.name.value = newTheme
+      document.documentElement.classList.toggle('light', newTheme === 'light')
+    },
+  })
+
+  onMounted(() => {
+    document.documentElement.classList.toggle('light', !isDark.value)
+  })
+
   const linklist = ref([
     {
       icon: 'mdi-monitor-dashboard',

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -16,16 +16,29 @@ import 'vuetify/styles'
 // https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
 export default createVuetify({
   theme: {
-    defaultTheme: 'system',
-    myTheme: {
-      dark: true,
-      colors: {
-        primary: 'var(--color-primary)',
-        secondary: 'var(--color-secondary)',
-        success: 'var(--color-success)',
-        warning: 'var(--color-warning)',
-        error: 'var(--color-error)',
-        textmain: 'var(--color-text-main)',
+    defaultTheme: 'dark',
+    themes: {
+      dark: {
+        dark: true,
+        colors: {
+          primary: 'var(--color-primary)',
+          secondary: 'var(--color-secondary)',
+          success: 'var(--color-success)',
+          warning: 'var(--color-warning)',
+          error: 'var(--color-error)',
+          textmain: 'var(--color-text-main)',
+        },
+      },
+      light: {
+        dark: false,
+        colors: {
+          primary: 'var(--color-primary)',
+          secondary: 'var(--color-secondary)',
+          success: 'var(--color-success)',
+          warning: 'var(--color-warning)',
+          error: 'var(--color-error)',
+          textmain: 'var(--color-text-main)',
+        },
       },
     },
   },

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -29,3 +29,27 @@
   --color-card-glass: rgba(35,41,66,0.85);
   --box-shadow-card: 0 2px 12px rgba(68,108,252,0.05);
 }
+
+:root.light {
+  --color-primary: #446cfc;
+  --color-secondary: #30c7d5;
+
+  --color-bg-main: #f5f7ff;
+  --color-bg-card: #ffffff;
+  --color-bg-nav: #446cfc;
+
+  --color-text-main: #1e1e1e;
+  --color-text-secondary: #333333;
+
+  --color-border: #e0e0e0;
+
+  --color-success: #1fcb81;
+  --color-warning: #ffc542;
+  --color-error: #f24848;
+
+  --color-download: #1fd47c;
+  --color-upload: #f5b941;
+
+  --color-card-glass: rgba(255,255,255,0.85);
+  --box-shadow-card: 0 2px 12px rgba(0,0,0,0.05);
+}


### PR DESCRIPTION
## Summary
- add Vuetify light theme variables
- configure Vuetify with light and dark themes
- add navigation switch to toggle dark mode

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a26b9e4f088324b33d405032847296